### PR TITLE
fix-mispell-again-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ List of Words that Should be Spelled Correctly
 
 - zzabout
 - zzafter
-- zzagain
+- again
 - zzair
 - zzall
 - zzalong


### PR DESCRIPTION
Fix misspelling of again

The word again includes an unnecessary "zz" at the beginning of the word.

Fix #24